### PR TITLE
Add Repohistory

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 - [Matomo](https://github.com/matomo-org/matomo) - Matomo is the leading open alternative to Google Analytics that gives you full control over your data. Matomo lets you easily collect data from websites, apps & the IoT and visualise this data and extract insights. 
 - [Open-Web-Analytics](http://www.openwebanalytics.com/) - Open Web Analytics is an open source alternative to commercial tools such as Google Analytics. Stay in control of the data you collect about the use of your website or app.
 - [Plausible](https://github.com/plausible/analytics/) - [Plausible Analytics](https://plausible.io/) is a simple, lightweight (< 1 KB), open-source and privacy-friendly alternative to Google Analytics. It doesn’t use cookies and is fully compliant with GDPR, CCPA and PECR.
+- [Repohistory](https://github.com/repohistory/repohistory) - [Repohistory](https://repohistory.com) is an analytics tool for tracking GitHub repo traffic history longer than 14 days.
 - [Umami](https://github.com/mikecao/umami) - [Umami](https://umami.is/) is a simple, fast, website analytics alternative to Google Analytics.
 
 ## Asset Management


### PR DESCRIPTION
This PR adds [Repohistory](https://github.com/repohistory/repohistory) - An analytics tool for tracking GitHub repo traffic history longer than 14 days.