### PR TITLE
Add Beam — cookie-free web analytics platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [Plausible](https://github.com/plausible/analytics/) - [Plausible Analytics](https://plausible.io/) is a simple, lightweight (< 1 KB), open-source and privacy-friendly alternative to Google Analytics. It doesn’t use cookies and is fully compliant with GDPR, CCPA and PECR.
 - [Repohistory](https://github.com/repohistory/repohistory) - [Repohistory](https://repohistory.com) is an analytics tool for tracking GitHub repo traffic history longer than 14 days.
 - [Umami](https://github.com/mikecao/umami) - [Umami](https://umami.is/) is a simple, fast, website analytics alternative to Google Analytics.
+- [Beam](https://github.com/scobb/beam.js) - [Beam](https://beam-privacy.com/) is a lightweight, cookie-free web analytics platform built on Cloudflare Workers and D1. No cookies, no fingerprinting, GDPR-compliant by design. Free tier: 50K pageviews/month. Pro: $5/month.
 
 ## Asset Management
 


### PR DESCRIPTION
Adding [Beam](https://beam-privacy.com) to the Analytics section.

Beam is a lightweight, privacy-first web analytics platform built on Cloudflare Workers and D1:

- **Cookie-free**: no consent banners required (GDPR-compliant by design)
- **Open-source tracking script**: [scobb/beam.js](https://github.com/scobb/beam.js) (MIT)
- **Free tier**: 1 site, 50,000 pageviews/month
- **Pro**: $5/month, unlimited sites, 500K pageviews/month
- **Sub-2KB script** (vs Google Analytics 45KB+)

A privacy-respecting alternative to Google Analytics, Plausible, and Fathom.