### PR TITLE
Add TinyTools BG Remover to Image Manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@
 - [Fotoxx](https://gitlab.com/fotoxx/fotoxx) - Fotoxx is a free open source Linux program for photo/image editing and collection management. The goal is to meet the needs of serious photographers while remaining fast and easy to use. 
 - [Gimp](https://gitlab.gnome.org/GNOME/gimp) - Gimp is a free and open-source raster graphics editor used for image manipulation (retouching) and image editing.
 - [Krita](https://github.com/KDE/krita) - Krita is a professional FREE and open source painting program. It is made by artists that want to see affordable art tools for everyone.
+- [TinyTools BG Remover](https://github.com/alfredoautomatizaloconia-cloud/tinytools) - Free, open-source AI background remover that runs entirely in the browser using ONNX/WASM. No upload, no signup, no server processing — images never leave the user's device. Live at https://tinytools-smoky.vercel.app/.
 
 ## File Manipulation
 


### PR DESCRIPTION
Hi! I'd like to add **TinyTools BG Remover** to the Image Manipulation section.

It's a free, open-source background remover that runs entirely in the browser via ONNX/WASM — no upload, no server, no signup. Images never leave the user's device.

- Live: https://tinytools-smoky.vercel.app/
- Source: https://github.com/alfredoautomatizaloconia-cloud/tinytools

It complements the existing desktop tools (Gimp, Krita, Fotoxx) by offering an instant browser-based option for one specific task. Thanks for maintaining this list!