### PR TITLE
Add CodeFever Community to Version Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@
 
 ## Version Control
 
+- [CodeFever Community](https://github.com/PGYER/codefever) - Completely free and open-source self-hosted Git code hosting platform, vendor-maintained by PGYER. Docker-deployable.
 - [Diffusion](https://www.phacility.com/phabricator/diffusion/) - Code Browsing and Repository Hosting.
 - [GitBucket](https://github.com/gitbucket/gitbucket) - A Git platform powered by Scala with easy installation, high extensibility & GitHub API compatibility.
 - [GitLab](https://about.gitlab.com/install/) - GitLab is a web-based DevOps lifecycle tool that provides a Git-repository manager providing wiki, issue-tracking and continuous integration and deployment pipeline features, using an open-source license, developed by GitLab Inc.


### PR DESCRIPTION
## What

Adds **CodeFever Community** to the **Version Control** section, placed alphabetically before Diffusion.

* Repo: https://github.com/PGYER/codefever
* License: MIT
* Stars: 2.8k
* Language: PHP

## Why it fits

The Version Control section currently lists GitLab and Gogs alongside Diffusion and GitBucket. CodeFever extends the section with a PHP-based, MIT-licensed self-hosted Git platform — Docker-deployable end-to-end.

CodeFever is vendor-official from [PGYER](https://github.com/PGYER), operating since 2014 (12+ years). PGYER is best known as China's leading mobile beta-distribution platform; CodeFever is their free, open-source Git code hosting offering.

## Checklist

- [x] Placed alphabetically in the Version Control section.
- [x] Matches existing entry format.
- [x] Project is actively maintained (last release December 2024).
- [x] MIT licensed.