### PR TITLE
Add Lockpaw (resubmission of #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@
 
 - [BunkerWeb](https://github.com/bunkerity/bunkerweb) - BunkerWeb is a next-generation and open-source Web Application Firewall (WAF). It is a full-featured web server (based on NGINX under the hood) to protect web services to make them "secure by default".
 - [amnezia](https://amnezia.org/en) - Amnezia is an open-source VPN client, with a key feature that enables you to deploy your own VPN server on your server.
+- [Lockpaw](https://github.com/sorkila/lockpaw) - [Lockpaw](https://getlockpaw.com) is a free, MIT-licensed macOS menu bar screen guard. Lock your screen with a hotkey without sleeping — builds and AI agents keep running with input blocked, the locked screen glows when your agent needs you, and Touch ID unlocks.
 - [tirreno](https://github.com/TirrenoTechnologies/tirreno) - [tirreno](https://www.tirreno.com/) is an open-source cyberfraud protection platform.
 
 ## Social Network


### PR DESCRIPTION
Hi! This resubmits #16, which was auto-closed when I accidentally deleted the source fork during a cleanup — it wasn't rejected, so apologies for the noise.

[Lockpaw](https://getlockpaw.com) ([repo](https://github.com/sorkila/lockpaw)) is a macOS menu bar screen guard: lock your screen with a hotkey without putting the Mac to sleep, so builds and AI agents keep running with input blocked, and the locked screen glows when your agent needs you. Free, MIT-licensed, native Swift, no telemetry. Added under Security, matching the existing entry format. Thanks for considering it again!