### PR TITLE
Add ItsPaint to Image Manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@
 
 - [Fotoxx](https://gitlab.com/fotoxx/fotoxx) - Fotoxx is a free open source Linux program for photo/image editing and collection management. The goal is to meet the needs of serious photographers while remaining fast and easy to use. 
 - [Gimp](https://gitlab.gnome.org/GNOME/gimp) - Gimp is a free and open-source raster graphics editor used for image manipulation (retouching) and image editing.
+- [ItsPaint](https://github.com/joshlin2201/itspaint) - ItsPaint is a free and open source native macOS paint and image editor for blank-canvas drawing, cropping, screenshot markup and background removal.
 - [Krita](https://github.com/KDE/krita) - Krita is a professional FREE and open source painting program. It is made by artists that want to see affordable art tools for everyone.
 
 ## File Manipulation


### PR DESCRIPTION
Adding [ItsPaint](https://github.com/joshlin2201/itspaint) to **Image Manipulation**, alphabetically between Gimp and Krita.

A native macOS paint and image editor: blank canvas at any size, crop, paste one image onto another, screenshot markup with numbered step badges and pixelate, and background removal with no model. MIT, no third-party dependencies, notarised, and free on the Mac App Store. Written in Swift 6, and the drawing engine is a UI-free SwiftPM package with 288 tests that run in a fresh clone with no Xcode.

macOS only, which the description says rather than implying otherwise. If the list is really collecting cross-platform systems, say so and I will close it.
