### PR TITLE
Add YunCMS to Content Management Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@
 - [PyroCMS](https://github.com/pyrocms/pyrocms) - PyroCMS is an easy to use, powerful, and modular CMS and development platform built with Laravel 5.
 - [TYPO3](https://get.typo3.org/) - TYPO3 is a free and open-source Web content management system written in PHP.
 - [WordPress](https://wordpress.org/download/) - WordPress is a free and open-source content management system written in PHP and paired with a MySQL or MariaDB database.
+- [YunCMS](https://github.com/Yunsoft-Software/yuncms) - A self-hosted MySQL CMS and REST backend with a React administration Studio, role-based access control, Files, extensions, and optional MCP.
 
 ## Code Quality
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@
 - [PyroCMS](https://github.com/pyrocms/pyrocms) - PyroCMS is an easy to use, powerful, and modular CMS and development platform built with Laravel 5.
 - [TYPO3](https://get.typo3.org/) - TYPO3 is a free and open-source Web content management system written in PHP.
 - [WordPress](https://wordpress.org/download/) - WordPress is a free and open-source content management system written in PHP and paired with a MySQL or MariaDB database.
-- [YunCMS](https://github.com/Yunsoft-Software/yuncms) - A self-hosted MySQL CMS and REST backend with a React administration Studio, role-based access control, Files, extensions, and optional MCP.
+- [YunCMS](https://github.com/Yunsoft-Software/yuncms) - A self-hosted MySQL CMS and REST backend with a React administration Studio, role-based access control, Files, extensions, and optional MCP. Website: [Yunsoft](https://yunsoft.com).
 
 ## Code Quality
 


### PR DESCRIPTION
Adds [YunCMS](https://github.com/Yunsoft-Software/yuncms) to the Content Management Systems section. YunCMS is a public MIT-licensed, self-hosted MySQL CMS and REST backend with a React administration Studio, RBAC, Files, extensions, and optional MCP.

The project is currently in the documented 0.1.x pre-stable phase; this submission does not imply otherwise.

Validation: git diff --check passed. npx awesome-lint was also run; the repository currently has pre-existing list-wide findings, and the new YunCMS line was not cited.

Disclosure: I am submitting this on behalf of the YunCMS project.