### PR TITLE
Add Posnic POS

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@
 - [Odoo](https://github.com/odoo/odoo) - [Odoo](https://www.odoo.com/) is a suite of web based open source business apps, built with python.
 - [IDURAR ERP CRM](https://github.com/idurar/idurar-erp-crm) - [idurarapp.com](https://www.idurarapp.com/) is Open Code Source ERP CRM based on Mern-stack (Mongodb , Express.js , React , Node.js)
 - [NexoPOS](https://github.com/Blair2004/NexoPOS) - The base version of NexoPOS, which is a web-Based Point Of Sale (POS) System build with Laravel, TailwindCSS, and Vue.Js.
-- [Posnic](https://github.com/Posnic/POS) - Offline-first open source POS and billing software for retail shops and restaurants, with local checkout, self-hosted server setup, inventory, reports, and optional cloud services.
+- [Posnic](https://github.com/Posnic/POS) - Offline-first open source POS and billing software for retail shops and restaurants, with local checkout, inventory, reports, and self-hosted online/offline workflows. [Official site](https://posnic.io/).
 - [jshERP](https://github.com/jishenghua/jshERP) - The ERP system is developed by JshERP.
 
 ## Event Management

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@
 - [Odoo](https://github.com/odoo/odoo) - [Odoo](https://www.odoo.com/) is a suite of web based open source business apps, built with python.
 - [IDURAR ERP CRM](https://github.com/idurar/idurar-erp-crm) - [idurarapp.com](https://www.idurarapp.com/) is Open Code Source ERP CRM based on Mern-stack (Mongodb , Express.js , React , Node.js)
 - [NexoPOS](https://github.com/Blair2004/NexoPOS) - The base version of NexoPOS, which is a web-Based Point Of Sale (POS) System build with Laravel, TailwindCSS, and Vue.Js.
+- [Posnic](https://github.com/Posnic/POS) - Offline-first open source POS and billing software for retail shops and restaurants, with local checkout, self-hosted server setup, inventory, reports, and optional cloud services.
 - [jshERP](https://github.com/jishenghua/jshERP) - The ERP system is developed by JshERP.
 
 ## Event Management

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@
 - [Odoo](https://github.com/odoo/odoo) - [Odoo](https://www.odoo.com/) is a suite of web based open source business apps, built with python.
 - [IDURAR ERP CRM](https://github.com/idurar/idurar-erp-crm) - [idurarapp.com](https://www.idurarapp.com/) is Open Code Source ERP CRM based on Mern-stack (Mongodb , Express.js , React , Node.js)
 - [NexoPOS](https://github.com/Blair2004/NexoPOS) - The base version of NexoPOS, which is a web-Based Point Of Sale (POS) System build with Laravel, TailwindCSS, and Vue.Js.
-- [Posnic](https://github.com/Posnic/POS) - Offline-first open source POS and billing software for retail shops and restaurants, with local checkout, inventory, reports, and self-hosted online/offline workflows. [Official site](https://posnic.io/).
+- [Posnic](https://github.com/Posnic/POS) - Offline-first open source POS and billing software for retail shops and restaurants, with local checkout, inventory, reports, and self-hosted online/offline workflows. [Official site](https://www.posnic.com/).
 - [jshERP](https://github.com/jishenghua/jshERP) - The ERP system is developed by JshERP.
 
 ## Event Management


### PR DESCRIPTION
## Summary
- Add Posnic to Enterprise Resource Planning (ERP), next to existing POS/ERP tools.
- Link to https://github.com/Posnic/POS as the public source.
- Use bounded language for open source POS, billing software, offline checkout, self-hosted server setup, inventory, reports, and optional cloud services.

## Validation
- Confirmed there is no existing Posnic PR and issues are disabled.
- Verified https://github.com/Posnic/POS, the latest release URL, and https://www.posnic.com/ return HTTP 200.
- Ran `git diff --check` locally.

## Fit
The list already includes NexoPOS in ERP; Posnic is AGPL-3.0 licensed, actively maintained, documented, and has a public stable release.

I am affiliated with Posnic and prepared this contribution with automation assistance.

